### PR TITLE
Update metadata.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and to monitor status by status script.
 
 ## Installation
 
-Install this plasmoid using `plasmapkg2 --install .` in the plasmoid directory.
+Install this plasmoid using `kpackagetool6 --type Plasma/Applet --install .` in the plasmoid directory.
 
 ## Configuration
 The plasmoid can by configured in the settings menu:

--- a/metadata.json
+++ b/metadata.json
@@ -14,12 +14,10 @@
         "License": "GPL",
         "Name": "Configurable Button",
         "Name[en_GB]": "Configurable Button",
-        "ServiceTypes": [
-            "Plasma/Applet"
-        ],
         "Version": "0.2.0",
         "Website": "https://github.com/pmarki/plasmoid-button"
     },
+    "KPackageStructure": "Plasma/Applet",
     "X-Plasma-API-Minimum-Version": "6.0",
     "X-Plasma-API": "declarativeappletscript",
     "X-Plasma-MainScript": "ui/main.qml"


### PR DESCRIPTION
Fixed definition as "Plasma/Applet". This caused the scaling to  not work when in a vertical panel.
Tested with Plasmashell 6.2.5